### PR TITLE
Read from .git/hooks/pre-commit to get right path to pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "dependencies": {
         "find-up": "^4.1.0",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.15",
-        "p-locate": "^4.1.0",
-        "path-exists": "^4.0.0"
+        "lodash": "^4.17.15"
     },
     "devDependencies": {
         "@babel/core": "^7.7.5",


### PR DESCRIPTION
Rather than assuming `pre-commit` lives at `venv/bin/pre-commit`, this lets us grab what python would be on $PATH, and run `python -m pre_commit`.

(thanks to @asottile for [this suggestion](https://twitter.com/codewithanthony/status/1202499585593110528))